### PR TITLE
Include provision scripts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2022
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,24 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2022
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+name: Lint Code Base
+# yamllint disable-line rule:truthy
+on: [push, pull_request]
+
+jobs:
+  check-super-linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.1.0
+      - name: Check super-linter
+        uses: github/super-linter@v4.9.7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINTER_RULES_PATH: /

--- a/.github/workflows/on-demand_ci.yml
+++ b/.github/workflows/on-demand_ci.yml
@@ -1,0 +1,50 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2022
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+name: Check End-to-End (On Demand)
+# yamllint disable-line rule:truthy
+on:
+  push:
+    paths:
+      - '**.sh'
+      - '!.github/*'
+  pull_request_review:
+    types:
+      - submitted
+
+jobs:
+  check-scripts-format:
+    name: Check scripts format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.1.0
+      - name: Run the sh-checker
+        uses: luizm/action-sh-checker@v0.5.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHFMT_OPTS: -i 4 -s
+        with:
+          sh_checker_shellcheck_disable: true
+  functional-test:
+    name: Check functional tests
+    if: >-
+      (
+        github.event_name == 'pull_request_review' &&
+        github.event.review.state == 'approved'
+      ) ||
+      github.event_name != 'pull_request_review'
+    runs-on: ubuntu-20.04
+    env:
+      DEBUG: true
+    steps:
+      - uses: actions/checkout@v3.1.0
+      - name: Install dependencies and configures kind clusters
+        working-directory: ./scripts
+        run: ./install.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vagrant
+*.log

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2022
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+DOCKER_CMD ?= $(shell which docker 2> /dev/null || which podman 2> /dev/null || echo docker)
+
+
+.PHONY: lint
+lint:
+	sudo -E $(DOCKER_CMD) run --rm -v $$(pwd):/tmp/lint \
+	-e RUN_LOCAL=true \
+	-e LINTER_RULES_PATH=/ \
+	-e VALIDATE_KUBERNETES_KUBEVAL=false \
+	github/super-linter
+
+.PHONY: fmt
+fmt:
+	sudo -E $(DOCKER_CMD) run --rm -u "$$(id -u):$$(id -g)" \
+	-v "$$(pwd):/mnt" -w /mnt mvdan/shfmt -l -w -i 4 -s .

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+##############################################################################
+# Copyright (c) 2022
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+host = RbConfig::CONFIG['host_os']
+
+no_proxy = ENV['NO_PROXY'] || ENV['no_proxy'] || '127.0.0.1,localhost'
+(1..254).each do |i|
+  no_proxy += ",10.0.2.#{i}"
+end
+
+case host
+when /darwin/
+  mem = `sysctl -n hw.memsize`.to_i / 1024
+when /linux/
+  mem = `grep 'MemTotal' /proc/meminfo | sed -e 's/MemTotal://' -e 's/ kB//'`.to_i
+when /mswin|mingw|cygwin/
+  mem = `wmic computersystem Get TotalPhysicalMemory`.split[1].to_i / 1024
+end
+
+# rubocop:disable Metrics/BlockLength
+Vagrant.configure('2') do |config|
+  # rubocop:enable Metrics/BlockLength
+  config.vm.provider :libvirt
+  config.vm.provider :virtualbox
+
+  config.vm.box = 'generic/ubuntu2004'
+  config.vm.box_check_update = false
+  config.vm.synced_folder './', '/vagrant'
+
+  config.vm.provision 'shell', privileged: false, path: './scripts/install.sh', reset: true
+
+  %i[virtualbox libvirt].each do |provider|
+    config.vm.provider provider do |p|
+      p.cpus = ENV['CPUS'] || 3
+      p.memory = ENV['MEMORY'] || mem / 1024 / 4
+    end
+  end
+
+  config.vm.provider 'virtualbox' do |v|
+    v.gui = false
+    v.customize ['modifyvm', :id, '--nictype1', 'virtio', '--cableconnected1', 'on']
+    # Enable nested paging for memory management in hardware
+    v.customize ['modifyvm', :id, '--nestedpaging', 'on']
+    # Use large pages to reduce Translation Lookaside Buffers usage
+    v.customize ['modifyvm', :id, '--largepages', 'on']
+    # Use virtual processor identifiers  to accelerate context switching
+    v.customize ['modifyvm', :id, '--vtxvpid', 'on']
+  end
+
+  config.vm.provider :libvirt do |v, override|
+    override.vm.synced_folder './', '/vagrant', type: 'virtiofs'
+    v.memorybacking :access, mode: 'shared'
+    v.random_hostname = true
+    v.management_network_address = '10.0.2.0/24'
+    v.management_network_name = 'administration'
+    v.cpu_mode = 'host-passthrough'
+  end
+
+  if !ENV['http_proxy'].nil? && !ENV['https_proxy'].nil? && Vagrant.has_plugin?('vagrant-proxyconf')
+    config.proxy.http = ENV['http_proxy'] || ENV['HTTP_PROXY'] || ''
+    config.proxy.https    = ENV['https_proxy'] || ENV['HTTPS_PROXY'] || ''
+    config.proxy.no_proxy = no_proxy
+    config.proxy.enabled = { docker: false }
+  end
+end

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2022
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+set -o pipefail
+set -o errexit
+set -o nounset
+if [[ ${DEBUG:-false} == "true" ]]; then
+    set -o xtrace
+    export PKG_DEBUG=true
+fi
+
+export PKG_KREW_PLUGINS_LIST=" "
+
+declare -A clusters
+clusters=(
+    ["nephio"]="172.88.0.0/16,10.196.0.0/16,10.96.0.0/16"
+    ["edge-cluster1"]="172.89.0.0/16,10.197.0.0/16,10.97.0.0/16"
+    ["edge-cluster2"]="172.90.0.0/16,10.198.0.0/16,10.98.0.0/16"
+)
+
+# Install dependencies
+# NOTE: Shorten link -> https://github.com/electrocucaracha/pkg-mgr_scripts
+curl -fsSL http://bit.ly/install_pkg | PKG_COMMANDS_LIST="kind,docker,kubectl" bash
+
+function deploy_k8s_cluster {
+    local name="$1"
+    local node_subnet="$2"
+    local pod_subnet="$3"
+    local svc_subnet="$4"
+
+    newgrp docker <<EONG
+if ! kind get clusters -q | grep -q $name; then
+    docker network create --driver bridge --subnet=$node_subnet $name
+    cat << EOF | KIND_EXPERIMENTAL_DOCKER_NETWORK=$name kind create cluster --name $name --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  kubeProxyMode: "ipvs"
+  podSubnet: "$pod_subnet"
+  serviceSubnet: "$svc_subnet"
+nodes:
+  - role: control-plane
+EOF
+fi
+EONG
+}
+
+for cluster in "${!clusters[@]}"; do
+    read -a subnets <<<"${clusters[$cluster]//,/ }"
+    deploy_k8s_cluster "$cluster" "${subnets[0]}" "${subnets[1]}" "${subnets[2]}"
+done
+
+# Wait for node readiness
+for context in $(kubectl config get-contexts --no-headers --output name); do
+    kubectl config use-context "$context"
+    for node in $(kubectl get node -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'); do
+        kubectl wait --for=condition=ready "node/$node" --timeout=3m
+    done
+done


### PR DESCRIPTION
This change includes the `install.sh` script used for the installation and provision of kind clusters. The `Vagrantfile` is included here for testing changes locally.