### PR TITLE
Add workers for kind clusters

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -47,6 +47,9 @@ networking:
   serviceSubnet: "$svc_subnet"
 nodes:
   - role: control-plane
+  - role: worker
+  - role: worker
+  - role: worker
 EOF
 fi
 EONG


### PR DESCRIPTION
Currently, only control-plan node is installed
Add 3 workers nodes for clusters deployed by kind
