### PR TITLE
Enable codespaces

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,11 @@
+{
+    "image": "mcr.microsoft.com/vscode/devcontainers/base:ubuntu-20.04",
+    "features": {
+        "ghcr.io/devcontainers/features/docker-in-docker:1": {}
+    },
+    "hostRequirements": {
+        "cpus": "4",
+        "memory": "8gb"
+    },
+    "postCreateCommand": "./scripts/install.sh"
+}


### PR DESCRIPTION
Apparently, GitHub has release [codespaces](https://github.com/features/codespaces) for public use in personal accounts. That gives the possibility to allow users to manage their own VM without relying on the Cloud resources. 