### PR TITLE
added subnet per cluster with different network contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ machine.
 # login from your workstation, forwarding 7007 -> localhost:7007 on the remote VM.
 ssh -L7007:localhost:7007 -i ~/.ssh/nephio ubuntu@$IP
 # now you are in the remote VM, in there run
-kubectl --kubeconfig ~/.kube/nephio.config port-forward --namespace=nephio-webui svc/nephio-webui 7007
+kubectl --kubeconfig ~/.kube/mgmt-config port-forward --namespace=nephio-webui svc/nephio-webui 7007
 ```
 On your workstation you can now browse to the URL
 [http://localhost:7007](http://localhost:7007), and you should see something
@@ -76,7 +76,7 @@ ssh -i ~/.ssh/nephio ubuntu@$IP
 You can then check if you our cluster is working with `kubectl`:
 
 ```bash
-ubuntu@nephio-poc-001:~$ kubectl --kubeconfig ~/.kube/nephio.config -n nephio-system get pods
+ubuntu@nephio-poc-001:~$ kubectl --kubeconfig ~/.kube/mgmt-config -n nephio-system get pods
 NAME                                                        READY   STATUS    RESTARTS   AGE
 ipam-controller-65fb5fc8d4-5m8ts                            2/2     Running   0          24m
 nephio-5gc-controller-594cfd86b8-c9vbf                      2/2     Running   0          24m
@@ -388,26 +388,22 @@ spec:
           uplinkThroughput: "1G"
           downlinkThroughput: "10G"
         n3:
-          - networkInstance: "sample-vpc"
-            networkName: "sample-n3-net"
+          - networkInstance: "external-vpc"
         n4:
-          - networkInstance: "sample-vpc"
-            networkName: "sample-n4-net"
+          - networkInstance: "internal-vpc"
         n6:
           - dnn: "internet"
             uePool:
-              networkInstance: "sample-vpc"
-              networkName: "ue-net"
+              networkInstance: "internet-vpc"
               prefixSize: "16"
             endpoint:
-              networkInstance: "sample-vpc"
-              networkName: "sample-n6-net"
+              networkInstance: "internet-vpc"
 ```
 
 Then, you can deploy it with:
 
 ```bash
-kubectl --kubeconfig ~/.kube/nephio.config apply -f topo.yaml
+kubectl --kubeconfig ~/.kube/mgmt-config apply -f topo.yaml
 ```
 
 What does the system do with this resources?
@@ -500,29 +496,29 @@ resetting your environment.
 ```bash
 
 # Restart each controller
-kubectl --kubeconfig ~/.kube/nephio.config -n nephio-system rollout restart deploy package-deployment-controller-controller
-kubectl --kubeconfig ~/.kube/nephio.config -n nephio-system rollout restart deploy nephio-5gc-controller
-kubectl --kubeconfig ~/.kube/nephio.config -n nephio-system rollout restart deploy ipam-controller
-kubectl --kubeconfig ~/.kube/nephio.config -n nephio-system rollout restart deploy nf-injector-controller
+kubectl --kubeconfig ~/.kube/mgmt-config -n nephio-system rollout restart deploy package-deployment-controller-controller
+kubectl --kubeconfig ~/.kube/mgmt-config -n nephio-system rollout restart deploy nephio-5gc-controller
+kubectl --kubeconfig ~/.kube/mgmt-config -n nephio-system rollout restart deploy ipam-controller
+kubectl --kubeconfig ~/.kube/mgmt-config -n nephio-system rollout restart deploy nf-injector-controller
 
 # Check to see if the restart is done
-kubectl --kubeconfig ~/.kube/nephio.config -n nephio-system get po
+kubectl --kubeconfig ~/.kube/mgmt-config -n nephio-system get po
 ```
 
 ### Viewing Controller Logs
 
 ```bash
 # PackageDeployment controller
-kubectl --kubeconfig ~/.kube/nephio.config -n nephio-system logs -c controller -l app.kubernetes.io/name=package-deployment-controller
+kubectl --kubeconfig ~/.kube/mgmt-config -n nephio-system logs -c controller -l app.kubernetes.io/name=package-deployment-controller
 
 # FiveGCoreTopologyController
-kubectl --kubeconfig ~/.kube/nephio.config -n nephio-system logs -c controller -l app.kubernetes.io/name=nephio-5gc
+kubectl --kubeconfig ~/.kube/mgmt-config -n nephio-system logs -c controller -l app.kubernetes.io/name=nephio-5gc
 
 # NF Injector
-kubectl --kubeconfig ~/.kube/nephio.config -n nephio-system logs -c controller -l app.kubernetes.io/name=nf-injector
+kubectl --kubeconfig ~/.kube/mgmt-config -n nephio-system logs -c controller -l app.kubernetes.io/name=nf-injector
 
 # IPAM controller
-kubectl --kubeconfig ~/.kube/nephio.config -n nephio-system logs -c controller -l app.kubernetes.io/name=ipam
+kubectl --kubeconfig ~/.kube/mgmt-config -n nephio-system logs -c controller -l app.kubernetes.io/name=ipam
 ```
 
 ### Restarting the Web UI
@@ -530,11 +526,11 @@ kubectl --kubeconfig ~/.kube/nephio.config -n nephio-system logs -c controller -
 ```bash
 
 # Restart the deployment
-kubectl --kubeconfig ~/.kube/nephio.config -n nephio-webui rollout restart deploy nephio-webui
+kubectl --kubeconfig ~/.kube/mgmt-config -n nephio-webui rollout restart deploy nephio-webui
 
 # Check if the restart is complete
 
-kubectl --kubeconfig ~/.kube/nephio.config -n nephio-webui get po
+kubectl --kubeconfig ~/.kube/mgmt-config -n nephio-webui get po
 ```
 
 ### Cleaning Up Everything

--- a/nephio-ansible-install/README.md
+++ b/nephio-ansible-install/README.md
@@ -65,6 +65,11 @@ all:
       edge1: {mgmt_subnet: 172.89.0.0/16, pod_subnet: 10.197.0.0/16, svc_subnet: 10.97.0.0/16}
       edge2: {mgmt_subnet: 172.90.0.0/16, pod_subnet: 10.198.0.0/16, svc_subnet: 10.98.0.0/16}
       region1: {mgmt_subnet: 172.91.0.0/16, pod_subnet: 10.199.0.0/16, svc_subnet: 10.99.0.0/16}
+    networkInstances:
+      internal-vpc: {prefixes: [{prefix: 172.0.0.0/16, purpose: endpoint}]}
+      external-vpc: {prefixes: [{prefix: 172.1.0.0/16, purpose: endpoint}]}
+      sba-vpc: {prefixes: [{prefix: 172.2.0.0/16, purpose: endpoint}]}
+      internet-vpc: {prefixes: [{prefix: 172.3.0.0/16, purpose: endpoint}, {prefix: 10.0.0.0/8, purpose: pool}]}
   children:
     vm:
       hosts:

--- a/nephio-ansible-install/roles/docker/tasks/main.yaml
+++ b/nephio-ansible-install/roles/docker/tasks/main.yaml
@@ -6,7 +6,7 @@
 - name: check if docker already installed
   ansible.builtin.shell: service docker status
   register: docker_status
-  ignore_errors: yes
+  ignore_errors: true
 
 - include_tasks: "docker-{{ ansible_os_family }}.yaml"
   args:

--- a/nephio-ansible-install/roles/nephio/config/templates/5gc-topology.j2
+++ b/nephio-ansible-install/roles/nephio/config/templates/5gc-topology.j2
@@ -16,17 +16,13 @@ spec:
           uplinkThroughput: "1G"
           downlinkThroughput: "10G"
         n3:
-          - networkInstance: "sample-vpc"
-            networkName: "sample-n3-net"
+          - networkInstance: "external-vpc"
         n4:
-          - networkInstance: "sample-vpc"
-            networkName: "sample-n4-net"
+          - networkInstance: "internal-vpc"
         n6:
           - dnn: "internet"
             uePool:
-              networkInstance: "sample-vpc"
-              networkName: "ue-net"
+              networkInstance: "internet-vpc"
               prefixSize: "16"
             endpoint:
-              networkInstance: "sample-vpc"
-              networkName: "sample-n6-net"
+              networkInstance: "internet-vpc"

--- a/nephio-ansible-install/roles/nephio/config/templates/ipam.j2
+++ b/nephio-ansible-install/roles/nephio/config/templates/ipam.j2
@@ -1,48 +1,39 @@
+{% for niName, ni in networkInstances.items() %}
 ---
 apiVersion: ipam.nephio.org/v1alpha1
 kind: NetworkInstance
 metadata:
-  name: sample-vpc
+  name: {{ niName }}
 spec:
+  prefixes:
+{% for prefix in ni['prefixes'] %}
+  - prefix: {{prefix['prefix']}}
+    labels:
+      nephio.org/purpose: {{prefix['purpose']}}
+{% endfor %}
+{% endfor %}
+
+{% for clusterName, cluster in clusters.items() %}
+{% set outer_loop = loop %}
+{% for niName, ni in networkInstances.items() %}
+{% for prefix in ni['prefixes'] %}
+{% if prefix['purpose'] == 'endpoint' %}
 ---
 apiVersion: ipam.nephio.org/v1alpha1
 kind: IPPrefix
 metadata:
-  name: aggregate0
+  name: {{clusterName}}-{{niName}}
 spec:
-  kind: aggregate
-  prefix: 10.0.0.0/8
-  networkInstance: sample-vpc
----
-apiVersion: ipam.nephio.org/v1alpha1
-kind: IPPrefix
-metadata:
-  name: sample-n3-net-prefix1
+  prefix: "{{prefix['prefix'].split(".")[0]}}.{{prefix['prefix'].split(".")[1]}}.{{outer_loop.index}}.1/24"
+  networkInstanceRef: 
+    name: {{ niName }}
+    namespace: default
   labels:
     nephio.org/gateway: "true"
-spec:
-  prefix: 10.0.0.1/24
-  network: sample-n3-net
-  networkInstance: sample-vpc
----
-apiVersion: ipam.nephio.org/v1alpha1
-kind: IPPrefix
-metadata:
-  name: sample-n4-net-prefix1
-  labels:
-    nephio.org/gateway: "true"
-spec:
-  prefix: 192.168.1.1/24
-  network: sample-n4-net
-  networkInstance: sample-vpc
----
-apiVersion: ipam.nephio.org/v1alpha1
-kind: IPPrefix
-metadata:
-  name: sample-n6-net-prefix1
-  labels:
-    nephio.org/gateway: "true"
-spec:
-  prefix: 172.0.0.1/24
-  network: sample-n6-net
-  networkInstance: sample-vpc
+    nephio.org/purpose: {{prefix['purpose']}}
+    nephio.org/region: us-central1
+    nephio.org/site: {{ clusterName }}
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% endfor %}

--- a/nephio-ansible-install/roles/topo/deploy/tasks/main.yaml
+++ b/nephio-ansible-install/roles/topo/deploy/tasks/main.yaml
@@ -11,7 +11,7 @@
 
 - name: deploy topo
   become: true
-  shell: clab deploy -t {{ tmp_directory }}/topology.yaml
+  shell: clab deploy -t {{ tmp_directory }}/topology.yaml -c
   register: result
   failed_when:
     - result.rc > 1

--- a/nephio-ansible-install/roles/topo/deploy/templates/topology.yaml.j2
+++ b/nephio-ansible-install/roles/topo/deploy/templates/topology.yaml.j2
@@ -7,11 +7,14 @@ topology:
   nodes:
     srl:
       kind: srl
-{% for dict_item in clusters %}
-    {{dict_item}}-control-plane:
+{% for clusterName, cluster in clusters.items() %}
+    {{clusterName}}-control-plane:
        kind: ext-container
 {% endfor %}
   links:
-{% for dict_item in clusters %}
-    - endpoints: ["srl:e1-{{ loop.index }}", "{{dict_item}}-control-plane:eth1"]
+{% for clusterName, cluster in clusters.items() %}
+{% set outer_loop = loop %}
+{% for niName, ni in networkInstances.items() %}
+    - endpoints: ["srl:e1-{{ 2 + loop.index + ((outer_loop.index -1) * (networkInstances | length)) }}", "{{clusterName}}-control-plane:eth{{ loop.index }}"]
+{% endfor %}
 {% endfor %}


### PR DESCRIPTION
WARNING: this PR  also requires a change in the IPAM/NF-injector controller, NAD-injector fn and the ipam package in the Nephio-packages !!!!

This PR configures a subnet per cluster per network-type (internal/external/sba/internet/etc) iso a single subnet for all clusters.
This enables a more real world environment, since a single broadcast network across clusters is not realistic.