### PR TITLE
Pre-install minimum hardware requirements check on host system

### DIFF
--- a/nephio-ansible-install/README.md
+++ b/nephio-ansible-install/README.md
@@ -49,6 +49,9 @@ all:
       no_proxy:
     host_os: "linux"  # use "darwin" for MacOS X, "windows" for Windows
     host_arch: "amd64"  # other possible values: "386","arm64","arm","ppc64le","s390x"
+    host_min_vcpu: 8 # minimum required vCPUs before install
+    host_min_cpu_ram: 32  # minimum required CPU RAM before install; value in GB
+    host_min_root_disk_space: 50 # minimum required disk space before install; value in GB
     tmp_directory: "/tmp"
     bin_directory: "/usr/local/bin"
     kubectl_version: "1.25.0"

--- a/nephio-ansible-install/nind/nephio.yaml
+++ b/nephio-ansible-install/nind/nephio.yaml
@@ -10,6 +10,9 @@ all:
       no_proxy:
     host_os: "linux"  # use "darwin" for MacOS X, "windows" for Windows
     host_arch: "amd64"  # other possible values: "386","arm64","arm","ppc64le","s390x"
+    host_min_vcpu: 8 # minimum required vCPUs before install
+    host_min_cpu_ram: 32  # minimum required CPU RAM before install; value in GB
+    host_min_root_disk_space: 50 # minimum required disk space before install; value in GB
     tmp_directory: "/tmp"
     bin_directory: "/usr/local/bin"
     kubectl_version: "1.25.0"

--- a/nephio-ansible-install/playbooks/install-prereq.yaml
+++ b/nephio-ansible-install/playbooks/install-prereq.yaml
@@ -1,4 +1,27 @@
 ---
+# Play to check for minimum hardware requirements on host system before proceeding with installation
+- hosts: vm
+  serial: 1
+
+  pre_tasks:
+    - name: Minimum requirements check before installing Nephio in system
+      block:
+        - name: Check if VM has minimum number of vCPUs to install Nephio
+          ansible.builtin.pause:
+            prompt: "VM does not have the minimum number of vCPUs - {{ ansible_facts['processor_vcpus'] }}. Minimum required vCPUs - {{ host_min_vcpu }}\nPress Ctrl + C for options or Enter/Return key to skip this warning"
+          when: ansible_facts['processor_vcpus'] | int < host_min_vcpu
+
+        - name: Check if VM has minimum CPU RAM to install Nephio
+          ansible.builtin.pause:
+            prompt: "VM does not have enough CPU RAM - {{ ansible_facts['memtotal_mb'] / 1024 }} GB. Minimum required CPU RAM - {{ host_min_cpu_ram }} GB\nPress Ctrl + C for options or Enter/Return key to skip this warning"
+          when: (ansible_facts['memtotal_mb'] / 1024) | int < host_min_cpu_ram
+
+        - name: Check if VM has enough disk space to install Nephio [root disk partition for Linux distros]
+          ansible.builtin.pause:
+            prompt: "VM does not have enough disk space {{ '{:0.2f}'.format((ansible_mounts|json_query('[?mount == `/`].size_available'))[0] / (1024|pow(3))) }} GB. Minimum required root disk partition space - {{ host_min_root_disk_space }} GB\nPress Ctrl + C for options or Enter/Return key to skip this warning"
+          when: ((ansible_mounts|json_query('[?mount == `/`].size_available'))[0] / (1024|pow(3))) | int < host_min_root_disk_space
+      when: ansible_facts['os_family'] == "RedHat" or ansible_facts['os_family'] == "Debian"
+
 - hosts: vm
   environment:
     http_proxy: "{{proxy.http_proxy}}"


### PR DESCRIPTION
Fixes #116 

Added a check to ensure minimum hardware specifications are met on host system that is used to install Nephio. The current requirements are as follows (taken from [nephio-ansible-install/README.md](https://github.com/nephio-project/one-summit-22-workshop/blob/main/nephio-ansible-install/README.md)):
- CPU RAM : 32 GB
- vCPUs: 8
- Disk space: 50 GB 

These values can be added by the user while creating the default inventory file _inventory/nephio.yaml_ and plugged in against the following variables:
- _host_min_vcpu_ : Minimum required number of vCPUs
- _host_min_cpu_ram_ : Minimum required CPU RAM value in GB
- _host_min_root_disk_space_ : Minimum required disk space (root disk partition for Linux distros) value in GB

The ansible play will now display warnings and pause for user prompts if any of the above requirements are not met (the current specification will also be displayed). Based on user prompts, the user can skip warnings and proceed with installation or abort the install entirely.


Key things to note:
1. This check would currently work only for systems that host Linux distros that belong to either the RedHat OS family or the Debian OS family as per Ansible.
2. The disk space requirement check is done only on the root disk partition.

List of files changed:
 - [nephio-ansible-install/playbooks/install-prereq.yaml](https://github.com/nephio-project/one-summit-22-workshop/blob/main/nephio-ansible-install/playbooks/install-prereq.yaml)
 - [nephio-ansible-install/README.md](https://github.com/nephio-project/one-summit-22-workshop/blob/main/nephio-ansible-install/README.md)
 - [nephio-ansible-install/nind/nephio.yaml](https://github.com/nephio-project/one-summit-22-workshop/blob/main/nephio-ansible-install/nind/nephio.yaml)