### PR TITLE
adds support for podman container runtime

### DIFF
--- a/nephio-ansible-install/README.md
+++ b/nephio-ansible-install/README.md
@@ -43,6 +43,7 @@ all:
     gitea_password: <gitea password>
     dockerhub_username: <dockerhub username>
     dockerhub_token: <dockerhub token or password>
+    container_engine: < either docker or podman>
     proxy:
       http_proxy: 
       https_proxy:

--- a/nephio-ansible-install/playbooks/deploy-clusters.yaml
+++ b/nephio-ansible-install/playbooks/deploy-clusters.yaml
@@ -8,4 +8,7 @@
     - {role: cluster/deploy, tags: cluster_deploy}
     - {role: topo/deploy, tags: topo_deploy}
     - {role: multus, tags: multus}
-    - {role: nephio/deploy, tags: nephio}
+    - role: nephio/deploy
+      tags: nephio
+      environment:
+        KPT_FN_RUNTIME: "{{ container_engine }}"

--- a/nephio-ansible-install/playbooks/install-prereq.yaml
+++ b/nephio-ansible-install/playbooks/install-prereq.yaml
@@ -1,26 +1,40 @@
 ---
 - hosts: vm
+
   environment:
     http_proxy: "{{proxy.http_proxy}}"
     https_proxy: "{{proxy.https_proxy}}"
     no_proxy: "{{proxy.no_proxy}}"
 
   pre_tasks:
+    - name: set fact for container engine
+      ansible.builtin.set_fact:
+        container_engine: docker
+      when: (container_engine is not defined)
+
     - name: install packages
       become: true
       ansible.builtin.package:
         name:
           - git
+          - wget
         state: present
 
   roles:
-    
-    - { role: docker, tags: docker}
+    - role: docker
+      tags: docker
+      when: ( container_engine is not defined ) or ( container_engine == "docker" )
+    - role: podman
+      tags: podman
+      when: container_engine == "podman"
     - { role: kubectl, tags: kubectl}
     - { role: kind, tags: kind}
     - { role: kpt, tags: kpt}
     - { role: cni, tags: cni }
     - { role: bash, tags: bash }
     - { role: tree, tags: tree}
-    - { role: nephio/install, tags: nephio}
+    - role: nephio/install
+      tags: nephio
+      environment:
+        KPT_FN_RUNTIME: "{{ container_engine }}"
     - { role: clab, tags: clab}

--- a/nephio-ansible-install/roles/cluster/deploy/tasks/cluster_files.yaml
+++ b/nephio-ansible-install/roles/cluster/deploy/tasks/cluster_files.yaml
@@ -2,33 +2,48 @@
 ## Licensed under the Apache License 2.0
 ## SPDX-License-Identifier: Apache-2.0
 ---
-- name: Copy cluster config template
+- name: Copy non-management cluster config template
   template:
     src: "{{ role_path }}/templates/cluster-config.yaml.j2"
     dest: "{{ tmp_directory }}/{{ item.key }}-cluster-config.yaml"
     mode: 0644
   tags:
     - create
+  when: item.key != "mgmt"
 
-- name: Add extra port mapping for mgmt cluster ingress
-  shell: |
-    cat <<EOF >> {{ tmp_directory }}/{{ item.key }}-cluster-config.yaml
-        kubeadmConfigPatches:
-        - |
-          kind: InitConfiguration
-          nodeRegistration:
-            kubeletExtraArgs:
-              node-labels: "ingress-ready=true"
-        extraPortMappings:
-        - containerPort: 80
-          hostPort: 7007
-          protocol: TCP
-    EOF
+- name: Copy managment cluster config template
+  template:
+    src: "{{ role_path }}/templates/mgmt-cluster-config.yaml.j2"
+    dest: "{{ tmp_directory }}/{{ item.key }}-cluster-config.yaml"
+    mode: 0644
+  tags:
+    - create
   when: item.key == "mgmt"
 
-- name: Deploy cluster {{ item.key }} 
-  shell: "kind create cluster --name {{ item.key }} --kubeconfig ~/.kube/{{ item.key }}-config --config {{ tmp_directory }}/{{ item.key }}-cluster-config.yaml"
+- name: Deploy docker cluster {{ item.key }}
+  shell: "kind create cluster --name {{ item.key }} --kubeconfig /home/{{ cloud_user }}/.kube/{{ item.key }}-config --config {{ tmp_directory }}/{{ item.key }}-cluster-config.yaml"
   register: result
   failed_when:
     - result.rc > 1
     - result.rc == 1 and "already exists" not in result.stderr
+  when: container_engine == "docker"
+
+- name: Deploy podman cluster {{ item.key }}
+  block: 
+    - name: create cluster
+      shell: "KIND_EXPERIMENTAL_PROVIDER=podman kind create cluster --name {{ item.key }} --kubeconfig /home/{{ cloud_user }}/.kube/{{ item.key }}-config --config {{ tmp_directory }}/{{ item.key }}-cluster-config.yaml"
+      register: result
+      failed_when:
+        - result.rc > 1
+        - result.rc == 1 and "already exists" not in result.stderr
+
+    - name: give {{ cloud_user }} permisions to the kubeconfig file when running {{ container_engine }}
+      ansible.builtin.file:
+        state: directory
+        path: /home/{{ cloud_user }}/.kube
+        owner: root
+        group: root
+        mode: '0775'
+        recurse: yes
+  when: container_engine == "podman"
+  become: true

--- a/nephio-ansible-install/roles/cluster/deploy/tasks/main.yaml
+++ b/nephio-ansible-install/roles/cluster/deploy/tasks/main.yaml
@@ -4,12 +4,14 @@
 ---
 - name: systctl config
   become: true
-  lineinfile: 
+  lineinfile:
     path: /etc/sysctl.conf
     line: "{{ item }}"
   with_items:
     - fs.inotify.max_user_watches=524288
     - fs.inotify.max_user_instances=512
+    - kernel.keys.maxkeys=500000
+    - kernel.keys.maxbytes=1000000
 
 - name: systctl config
   become: true
@@ -17,6 +19,8 @@
   with_items:
     - sysctl fs.inotify.max_user_watches=524288
     - sysctl fs.inotify.max_user_instances=512
+    - sysctl kernel.keys.maxkeys=500000
+    - sysctl kernel.keys.maxbytes=1000000
 
 - name: deploy clusters
   include_tasks: cluster_files.yaml

--- a/nephio-ansible-install/roles/cluster/deploy/templates/mgmt-cluster-config.yaml.j2
+++ b/nephio-ansible-install/roles/cluster/deploy/templates/mgmt-cluster-config.yaml.j2
@@ -1,0 +1,21 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  kubeProxyMode: "ipvs"
+  podSubnet: "{{ item.value.pod_subnet}}"
+  serviceSubnet: "{{ item.value.svc_subnet}}"
+nodes:
+  - role: control-plane
+    extraMounts:
+      - hostPath: "{{ tmp_directory }}/cni"
+        containerPath: /opt/cni/bin
+    kubeadmConfigPatches:
+    - |
+      kind: InitConfiguration
+      nodeRegistration:
+        kubeletExtraArgs:
+          node-labels: "ingress-ready=true"
+      extraPortMappings:
+      - containerPort: 80
+        hostPort: 7007
+        protocol: TCP

--- a/nephio-ansible-install/roles/dockerhub/login/tasks/docker.yaml
+++ b/nephio-ansible-install/roles/dockerhub/login/tasks/docker.yaml
@@ -1,0 +1,8 @@
+## © 2023 Nephio Authors
+## Licensed under the Apache License 2.0
+## SPDX-License-Identifier: Apache-2.0
+---
+- name: login into dockerhub using docker runtime
+  docker_login:
+    username: "{{ dockerhub_username }}"
+    password: "{{ dockerhub_token }}"

--- a/nephio-ansible-install/roles/dockerhub/login/tasks/main.yaml
+++ b/nephio-ansible-install/roles/dockerhub/login/tasks/main.yaml
@@ -2,8 +2,5 @@
 ## Licensed under the Apache License 2.0
 ## SPDX-License-Identifier: Apache-2.0
 ---
-
-- name: login into dockerhub
-  docker_login:
-    username: "{{ dockerhub_username }}"
-    password: "{{ dockerhub_token }}"
+- name: include tasks specific to "{{ container_engine }}"
+  ansible.builtin.include_tasks: "{{ container_engine }}.yaml"

--- a/nephio-ansible-install/roles/dockerhub/login/tasks/podman.yaml
+++ b/nephio-ansible-install/roles/dockerhub/login/tasks/podman.yaml
@@ -1,0 +1,9 @@
+## © 2023 Nephio Authors
+## Licensed under the Apache License 2.0
+## SPDX-License-Identifier: Apache-2.0
+---
+- name: login into dockerhub using podman runtime
+  containers.podman.podman_login:
+    username: "{{ dockerhub_username }}"
+    password: "{{ dockerhub_token }}"
+    registry: docker.io

--- a/nephio-ansible-install/roles/dockerhub/logout/tasks/main.yaml
+++ b/nephio-ansible-install/roles/dockerhub/logout/tasks/main.yaml
@@ -2,7 +2,13 @@
 ## Licensed under the Apache License 2.0
 ## SPDX-License-Identifier: Apache-2.0
 ---
-
-- name: logout of Dockerhub
+- name: logout of Dockerhub when using docker runtime
   docker_login:
     state: absent
+  when: (container_engine is not defined) or (container_engine  == 'docker')
+
+
+- name: logout of Dockerhub when using podman runtime
+  containers.podman.podman_logout:
+    registry: docker.io
+  when: (container_engine  == 'podman')

--- a/nephio-ansible-install/roles/gitea/create/tasks/docker.yaml
+++ b/nephio-ansible-install/roles/gitea/create/tasks/docker.yaml
@@ -1,0 +1,20 @@
+## © 2022 Nephio Authors
+## Licensed under the Apache License 2.0
+## SPDX-License-Identifier: Apache-2.0
+---
+- name: Start gitea container
+  docker_container:
+    name: gitea
+    image: gitea/gitea:1.17.3-rootless
+    networks:
+      - name: kind
+    #user: "{{ getent_passwd[cloud_user].1 }}:{{ getent_passwd[cloud_user].2 }}"
+    restart: yes
+    ports:
+      - "127.0.0.1:3000:3000/tcp"
+      - "127.0.0.1:2222:2222/tcp"
+    env:
+      GITEA_APP_INI: "/var/lib/gitea/custom/conf/app.ini"
+      INSTALL_LOCK: "true"
+    volumes:
+      - /home/{{ cloud_user }}/gitea:/var/lib/gitea:rw

--- a/nephio-ansible-install/roles/gitea/create/tasks/main.yaml
+++ b/nephio-ansible-install/roles/gitea/create/tasks/main.yaml
@@ -12,51 +12,40 @@
   ansible.builtin.file:
     path: /home/{{ cloud_user}}/gitea
     state: directory
-    owner: "{{ getent_passwd[cloud_user].1 }}"
-    group: "{{ getent_passwd[cloud_user].2 }}"
     mode: '0755'
-- name: Start gitea container
-  docker_container:
-    name: gitea
-    image: gitea/gitea:1.17.3-rootless
-    networks:
-      - name: kind
-    user: "{{ getent_passwd[cloud_user].1 }}:{{ getent_passwd[cloud_user].2 }}"
-    restart: yes
-    ports:
-      - "3000:3000"
-      - "2222:2222"
-    env:
-      GITEA_APP_INI: "/var/lib/gitea/custom/conf/app.ini"
-      INSTALL_LOCK: "true"
-    volumes:
-      - /home/{{ cloud_user }}/gitea:/var/lib/gitea:rw
+- name: Start gitea container when using "{{ container_engine }}"
+  ansible.builtin.include_tasks: "{{ container_engine }}.yaml"
   when:
     - gitea_username is defined
     - gitea_password is defined
-- name: Wait for gitea to initialise
-  ansible.builtin.wait_for:
-    path: /home/{{ cloud_user }}/gitea/ssh
-  when:
-    - gitea_username is defined
-    - gitea_password is defined
-- name: Creating nephio user in gitea
-  shell: |
-    docker exec gitea \
-      gitea admin user create \
-        --username {{ gitea_username }} \
-        --password {{ gitea_password }} \
-        --must-change-password=false \
-        --access-token \
-        --email=nephio@nephio.org > /home/{{ cloud_user }}/gitea/nephio-create
-  when:
-    - gitea_username is defined
-    - gitea_password is defined
-- name: Creating nephio user in gitea
-  shell: |
-    grep 'Access token was successfully created... ' /home/{{ cloud_user }}/gitea/nephio-create | \
-    sed 's/Access token was successfully created... //' | \
-    tr -d '\r\n' > /home/{{ cloud_user }}/gitea/nephio-gitea-token
+
+- block:
+    - name: Wait for gitea to initialise
+      ansible.builtin.wait_for:
+        path: /home/{{ cloud_user }}/gitea/ssh
+
+    - name: Creating nephio user in gitea
+      shell: |
+        {{ container_engine }} exec gitea gitea admin user create --username {{ gitea_username }} --password {{ gitea_password }} --must-change-password=false --access-token --email=nephio@nephio.org
+      register: user_cmd_output
+
+    - name: write output to a file
+      become: true
+      ansible.builtin.copy:
+        content: "{{ user_cmd_output }}"
+        dest: /home/{{ cloud_user }}/gitea/nephio-create
+
+    - name: capture gitea token
+      set_fact:
+        giteatoken: "{{ item | split('... ') | last }}"
+      when: item | regex_search('Access token was successfully created')
+      loop: "{{user_cmd_output.stdout_lines}}"
+
+    - name: write token to a file
+      become: true
+      ansible.builtin.copy:
+        content: "{{ giteatoken }}"
+        dest: /home/{{ cloud_user }}/gitea/nephio-gitea-token
   when:
     - gitea_username is defined
     - gitea_password is defined

--- a/nephio-ansible-install/roles/gitea/create/tasks/podman.yaml
+++ b/nephio-ansible-install/roles/gitea/create/tasks/podman.yaml
@@ -1,0 +1,22 @@
+## © 2022 Nephio Authors
+## Licensed under the Apache License 2.0
+## SPDX-License-Identifier: Apache-2.0
+---
+- name: reset directory ownership with podman unshare
+  ansible.builtin.shell: podman unshare chown {{ getent_passwd[cloud_user].1 }}:{{ getent_passwd[cloud_user].2 }} /home/{{ cloud_user }}/gitea
+
+- name: Start gitea container
+  containers.podman.podman_container:
+    name: gitea
+    image: docker.io/gitea/gitea:1.17.3-rootless
+    network: kind
+    user: "{{ getent_passwd[cloud_user].1 }}:{{ getent_passwd[cloud_user].2 }}"
+    restart: yes
+    ports:
+      - "127.0.0.1:3000:3000/tcp"
+      - "127.0.0.1:2222:2222/tcp"
+    env:
+      GITEA_APP_INI: "/var/lib/gitea/custom/conf/app.ini"
+      INSTALL_LOCK: "true"
+    volumes:
+      - /home/{{ cloud_user }}/gitea:/var/lib/gitea:Z

--- a/nephio-ansible-install/roles/podman/tasks/main.yaml
+++ b/nephio-ansible-install/roles/podman/tasks/main.yaml
@@ -1,0 +1,48 @@
+## © 2023 Nephio Authors
+## Licensed under the Apache License 2.0
+## SPDX-License-Identifier: Apache-2.0
+
+---
+- include_tasks: "podman-{{ ansible_os_family }}.yaml"
+  when: ansible_distribution == 'Ubuntu'
+
+- name: include podman pre-install tasks
+  ansible.builtin.include_tasks: pre-req.yaml
+
+- name: installing podman
+  become: true
+  ansible.builtin.package:
+    name: "podman"
+    state: latest
+
+- name: create podman network for kind
+  containers.podman.podman_network:
+    name: kind
+    driver: bridge
+
+- name: add docker alias for podman
+  lineinfile:
+    path=/home/{{ cloud_user }}/.bashrc
+    line="alias docker=podman"
+
+- name: source the file
+  shell: "source /home/{{ cloud_user }}/.bashrc"
+  args:
+    executable: /bin/bash
+
+# https://stackoverflow.com/questions/72690495/interact-with-podman-docker-via-socket-in-redhat-9
+- name: enable podman systemd units
+  block:
+    - name: Unmask and enable podman.socket
+      ansible.builtin.systemd:
+        name: podman.socket
+        enabled: true
+        state: started
+        masked: no
+    - name: Unmask, Enable and start podman.service
+      ansible.builtin.systemd:
+        name: podman.service
+        enabled: true
+        masked: no
+        state: started
+  become: true

--- a/nephio-ansible-install/roles/podman/tasks/podman-Debian.yaml
+++ b/nephio-ansible-install/roles/podman/tasks/podman-Debian.yaml
@@ -1,0 +1,23 @@
+## © 2023 Nephio Authors
+## Licensed under the Apache License 2.0
+## SPDX-License-Identifier: Apache-2.0
+
+---
+- name: fail if ubuntu version is below 22.04 and podman install is requested
+  ansible.builtin.fail:
+    msg: Ubuntu version to be 22.04 or greater when podman install is requested
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version | int < 22
+
+- name: setup apt repo for podman
+  block:
+    - name: kubic podman repo key add
+      become: true
+      ansible.builtin.get_url:
+        url: "https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_{{ ansible_distribution_version }}/Release.key"
+        dest: /etc/apt/trusted.gpg.d/kubic.key
+
+    - name: kubic podman repo apt source
+      become: true
+      ansible.builtin.apt_repository:
+        repo: "deb [signed-by=/etc/apt/trusted.gpg.d/kubic.key] https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_{{ ansible_distribution_version }}/ /"
+        state: present

--- a/nephio-ansible-install/roles/podman/tasks/pre-req.yaml
+++ b/nephio-ansible-install/roles/podman/tasks/pre-req.yaml
@@ -1,0 +1,23 @@
+## © 2023 Nephio Authors
+## Licensed under the Apache License 2.0
+## SPDX-License-Identifier: Apache-2.0
+
+---
+- name: create system directory related to podman
+  become: true
+  ansible.builtin.file:
+    path: /etc/systemd/system/user@.service.d
+    state: directory
+
+- name: setting systemd property "Delegate=yes"
+  become: true
+  ansible.builtin.copy:
+    content: |
+      [Service]
+      Delegate=yes
+    dest: /etc/systemd/system/user@.service.d/delegate.conf
+
+- name: system daemon reload
+  become: true
+  ansible.builtin.systemd:
+    daemon_reload: true

--- a/nephio-ansible-install/roles/topo/deploy/tasks/main.yaml
+++ b/nephio-ansible-install/roles/topo/deploy/tasks/main.yaml
@@ -11,8 +11,12 @@
 
 - name: deploy topo
   become: true
-  shell: clab deploy -t {{ tmp_directory }}/topology.yaml
+  shell: clab deploy -r {{ container_engine }} -t {{ tmp_directory }}/topology.yaml
   register: result
   failed_when:
     - result.rc > 1
     - result.rc == 1 and "already exists" not in result.stderr
+
+- name: output register debug
+  ansible.builtin.debug:
+    var: result

--- a/nephio-ansible-install/roles/topo/destroy/tasks/main.yaml
+++ b/nephio-ansible-install/roles/topo/destroy/tasks/main.yaml
@@ -5,4 +5,4 @@
 ---
 - name: destroy topo
   become: true
-  shell: clab destroy -t {{ tmp_directory }}/topology.yaml
+  shell: clab destroy -r {{ container_engine }} -t {{ tmp_directory }}/topology.yaml


### PR DESCRIPTION
fixes: #108

Co-authored-by: @steiler 

Note: Supports podman on Ubuntu 22.04 and greater only. Has been tested on Fedora 37 as well.