### PR TITLE
Fix missing vars in `inventory/nephio.yaml` for NIND (nephio-in-docker)

### DIFF
--- a/nephio-ansible-install/nind/nephio.yaml
+++ b/nephio-ansible-install/nind/nephio.yaml
@@ -5,6 +5,7 @@ all:
     gitea_username: nephio
     gitea_password: nephio
     validate_certs: true # change this to false if you want to avoid ssl/tls check
+    container_engine: docker # either docker or podman
     proxy:
       http_proxy: 
       https_proxy:

--- a/nephio-ansible-install/nind/nephio.yaml
+++ b/nephio-ansible-install/nind/nephio.yaml
@@ -4,6 +4,7 @@ all:
     cloud_user: user
     gitea_username: nephio
     gitea_password: nephio
+    validate_certs: true # change this to false if you want to avoid ssl/tls check
     proxy:
       http_proxy: 
       https_proxy:


### PR DESCRIPTION
Fixed the missing vars in `inventory/nephio.yaml` for NIND (nephio-in-docker) to avoid ansible errors.