### PR TITLE
ensures ingress-ready label is added to control-plane node of mgmt cluster

### DIFF
--- a/nephio-ansible-install/roles/nephio/deploy/tasks/mgmtcluster_files.yaml
+++ b/nephio-ansible-install/roles/nephio/deploy/tasks/mgmtcluster_files.yaml
@@ -62,9 +62,14 @@
     - gitea_username is defined
 
 - name: configure nephio ingress
-  shell: |
-    kubectl --kubeconfig ~/.kube/mgmt-config \
-      apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+  block:
+    - name: label the master node to indicate ingress ready (needed for non-KIND clusters)
+      shell: |
+        kubectl --kubeconfig ~/.kube/mgmt-config label nodes -l node-role.kubernetes.io/control-plane ingress-ready=true
+    - name: apply the ingress resource to nephio management cluster
+      shell: |
+        kubectl --kubeconfig ~/.kube/mgmt-config \
+          apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
 
 - name: wait for ingress controller
   shell: |


### PR DESCRIPTION
In order to be able to re-use the ansible scripts for non-KIND clusters as well, this PR enhances the nephio/deploy role to ensure that `ingress-ready=true` gets added to the `control-plane` node of the `mgmt` cluster before applying the ingress KRM resource